### PR TITLE
:sparkles: Editar chirps con autorización y eventos Livewire

### DIFF
--- a/app/Policies/ChirpPolicy.php
+++ b/app/Policies/ChirpPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Chirp;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ChirpPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Chirp $chirp): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Chirp $chirp): bool
+    {
+        return $chirp->user()->is($user);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Chirp $chirp): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Chirp $chirp): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Chirp $chirp): bool
+    {
+        return false;
+    }
+}

--- a/resources/views/livewire/chirps/edit.blade.php
+++ b/resources/views/livewire/chirps/edit.blade.php
@@ -1,0 +1,58 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Chirp;
+use Livewire\Attributes\Validate;
+
+new class extends Component {
+    public Chirp $chirp;
+
+
+
+    #[Validate('required|string|max:255')]
+    public string $message = '';
+
+
+    public function mount(): void
+    {
+        $this->message = $this->chirp->message;
+    }
+
+    public function update(): void
+    {
+
+        $this->authorize('update', $this->chirp);
+
+        $validated = $this->validate();
+
+        $this->chirp->update($validated);
+
+        $this->dispatch('chirp-updated');
+
+    }
+
+    public function cancel(): void
+    {
+        $this->dispatch('chirp-edit-canceled');
+    }
+}; ?>
+
+<div>
+    <form wire:submit="update"> 
+
+        <textarea
+
+            wire:model="message"
+
+            class="block w-full border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"
+
+        ></textarea>
+
+        <x-input-error :messages="$errors->get('message')" class="mt-2" />
+
+        <x-primary-button class="mt-4">{{ __('Save') }}</x-primary-button>
+
+        <button class="mt-4" wire:click.prevent="cancel">Cancel</button>
+
+    </form> 
+</div>

--- a/resources/views/livewire/chirps/list.blade.php
+++ b/resources/views/livewire/chirps/list.blade.php
@@ -7,8 +7,9 @@ use Livewire\Volt\Component;
 use Livewire\Attributes\On;
 
 new class extends Component {
-    public Collection $chirps;
 
+    public Collection $chirps;
+    public ?Chirp $editing = null;
 
 
     public function mount(): void
@@ -27,6 +28,26 @@ new class extends Component {
             ->get();
 
     }
+
+    public function edit(Chirp $chirp): void
+    {
+
+        $this->editing = $chirp;
+
+
+
+        $this->getChirps();
+
+    }
+
+    #[On('chirp-edit-canceled')]
+    #[On('chirp-updated')] 
+    public function disableEditing(): void
+    {
+        $this->editing = null;
+
+        $this->getChirps();
+    } 
 }; ?>
 
 <div class="mt-6 bg-white shadow-sm rounded-lg divide-y">
@@ -53,11 +74,56 @@ new class extends Component {
 
                         <small class="ml-2 text-sm text-gray-600">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
 
+                        @unless ($chirp->created_at->eq($chirp->updated_at))
+                            <small class="text-sm text-gray-600"> &middot; {{ __('edited') }}</small>
+                        @endunless
+
                     </div>
+                    @if ($chirp->user->is(auth()->user()))
+
+                        <x-dropdown>
+
+                            <x-slot name="trigger">
+
+                                <button>
+
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-gray-400" viewBox="0 0 20 20"
+                                        fill="currentColor">
+
+                                        <path
+                                            d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
+
+                                    </svg>
+
+                                </button>
+
+                            </x-slot>
+
+                            <x-slot name="content">
+
+                                <x-dropdown-link wire:click="edit({{ $chirp->id }})">
+
+                                    {{ __('Edit') }}
+
+                                </x-dropdown-link>
+
+                            </x-slot>
+
+                        </x-dropdown>
+
+                    @endif
 
                 </div>
 
-                <p class="mt-4 text-lg text-gray-900">{{ $chirp->message }}</p>
+                @if ($chirp->is($editing))
+
+                    <livewire:chirps.edit :chirp="$chirp" :key="$chirp->id" />
+
+                @else
+
+                    <p class="mt-4 text-lg text-gray-900">{{ $chirp->message }}</p>
+
+                @endif
 
             </div>
 


### PR DESCRIPTION
Agrega un formulario de edición condicional en el componente chirps.list.

Crea el componente chirps.edit con validación y autorización.

Escucha eventos chirp-updated y chirp-edit-canceled para actualizar la lista y cancelar la edición.

Define la política ChirpPolicy para restringir la edición al autor del Chirp.