### PR TITLE
:sparkles: Eliminar chirps

### DIFF
--- a/app/Policies/ChirpPolicy.php
+++ b/app/Policies/ChirpPolicy.php
@@ -45,7 +45,7 @@ class ChirpPolicy
      */
     public function delete(User $user, Chirp $chirp): bool
     {
-        return false;
+        return $this->update($user, $chirp);
     }
 
     /**

--- a/resources/views/livewire/chirps/list.blade.php
+++ b/resources/views/livewire/chirps/list.blade.php
@@ -48,6 +48,15 @@ new class extends Component {
 
         $this->getChirps();
     } 
+
+    public function delete(Chirp $chirp): void
+    {
+        $this->authorize('delete', $chirp);
+
+        $chirp->delete();
+
+        $this->getChirps();
+    } 
 }; ?>
 
 <div class="mt-6 bg-white shadow-sm rounded-lg divide-y">
@@ -65,11 +74,8 @@ new class extends Component {
             </svg>
 
             <div class="flex-1">
-
                 <div class="flex justify-between items-center">
-
                     <div>
-
                         <span class="text-gray-800">{{ $chirp->user->name }}</span>
 
                         <small class="ml-2 text-sm text-gray-600">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
@@ -77,16 +83,11 @@ new class extends Component {
                         @unless ($chirp->created_at->eq($chirp->updated_at))
                             <small class="text-sm text-gray-600"> &middot; {{ __('edited') }}</small>
                         @endunless
-
                     </div>
                     @if ($chirp->user->is(auth()->user()))
-
                         <x-dropdown>
-
                             <x-slot name="trigger">
-
                                 <button>
-
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-gray-400" viewBox="0 0 20 20"
                                         fill="currentColor">
 
@@ -94,18 +95,18 @@ new class extends Component {
                                             d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
 
                                     </svg>
-
                                 </button>
-
                             </x-slot>
-
                             <x-slot name="content">
-
+                                {{--* Options chirps menu context --}}
+                                {{--? Editar --}}
                                 <x-dropdown-link wire:click="edit({{ $chirp->id }})">
-
                                     {{ __('Edit') }}
-
                                 </x-dropdown-link>
+                                {{--! Eliminar --}}
+                                <x-dropdown-link wire:click="delete({{ $chirp->id }})" wire:confirm="Are you sure to delete this chirp?"> 
+                                    {{ __('Delete') }}
+                                </x-dropdown-link> 
 
                             </x-slot>
 


### PR DESCRIPTION
Se agregó la funcionalidad de eliminación en el componente de lista de Chirps con Livewire. Solo los autores pueden ver y usar el botón de eliminar. Se implementó autorización en ChirpPolicy reutilizando la lógica del método update.